### PR TITLE
[+] copy palette link by click on link icon

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -25,7 +25,7 @@ const propTypes = {
   snackBarText: PropTypes.string.isRequired,
   closeSnackBar: PropTypes.func.isRequired,
   showSnackBarWithText: PropTypes.func.isRequired,
-  paletteGenneratingUrl: PropTypes.string.isRequired,
+  activePageURL: PropTypes.string.isRequired,
 };
 
 const App = ({
@@ -35,14 +35,14 @@ const App = ({
   snackBarText,
   closeSnackBar,
   showSnackBarWithText,
-  paletteGenneratingUrl,
+  activePageURL,
 }) => (
   <MuiThemeProvider>
     <div className="app">
       <VisibleHeader />
       <Palette
         palette={palette}
-        paletteGenneratingUrl={paletteGenneratingUrl}
+        activePageURL={activePageURL}
         onClickPaletteButton={showPaletteCodeModal}
         onClickCopyPaletteButton={() => showSnackBarWithText('Link to the Palette successfully copied')}
       />

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -24,6 +24,8 @@ const propTypes = {
   isVisibleSnackBar: PropTypes.bool.isRequired,
   snackBarText: PropTypes.string.isRequired,
   closeSnackBar: PropTypes.func.isRequired,
+  showSnackBarWithText: PropTypes.func.isRequired,
+  paletteGenneratingUrl: PropTypes.string.isRequired,
 };
 
 const App = ({
@@ -32,11 +34,18 @@ const App = ({
   isVisibleSnackBar,
   snackBarText,
   closeSnackBar,
+  showSnackBarWithText,
+  paletteGenneratingUrl,
 }) => (
   <MuiThemeProvider>
     <div className="app">
       <VisibleHeader />
-      <Palette palette={palette} onClickPaletteButton={showPaletteCodeModal} />
+      <Palette
+        palette={palette}
+        paletteGenneratingUrl={paletteGenneratingUrl}
+        onClickPaletteButton={showPaletteCodeModal}
+        onClickCopyPaletteButton={() => showSnackBarWithText('Link to the Palette successfully copied')}
+      />
       <ComponentView palette={palette} />
       <Footer />
       <CopyCodeModal />

--- a/src/components/CopyCodeModal/CopyCodeModal.js
+++ b/src/components/CopyCodeModal/CopyCodeModal.js
@@ -50,7 +50,7 @@ class Modal extends Component {
     const actions = [
       <FlatButton label="Cancel" secondary onClick={() => this.onClose()} />,
       <CopyToClipboard text={currentText} onCopy={() => this.onClose(true)}>
-        <FlatButton label="Copy" parimary />
+        <FlatButton label="Copy" />
       </CopyToClipboard>,
     ];
 

--- a/src/components/Palette/Palette.css
+++ b/src/components/Palette/Palette.css
@@ -73,3 +73,16 @@
 .palette__table__td_text-black {
   color: black;
 }
+
+.palette-title__item {
+  display: inline-block;
+  vertical-align: middle;
+}
+.palette-title__copy-button {
+  margin-left: 5px;
+  color: slategray;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/src/components/Palette/Palette.js
+++ b/src/components/Palette/Palette.js
@@ -38,22 +38,14 @@ const propTypes = {
 const Palette = ({ palette, onClickPaletteButton, onClickCopyPaletteButton, activePageURL }) => (
   <div className="palette">
     <h1 className="title palette__title">
-      <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Palette</span>
-      <CopyToClipboard onCopy={(onClickCopyPaletteButton)} text={activePageURL}>
-        <i
-          role="button"
-          tabIndex={0}
-          className="material-icons"
-          style={{
-            display: 'inline-block',
-            verticalAlign: 'middle',
-            marginLeft: '5px',
-            color: 'slategray',
-            cursor: 'pointer',
-          }}
+      <span className="palette-title__item">Palette</span>
+      <CopyToClipboard onCopy={onClickCopyPaletteButton} text={activePageURL}>
+        <button
+          className="palette-title__copy-button palette-title__item material-icons"
+          aria-label="Copy Palette link to clipboard"
         >
           insert_link
-        </i>
+        </button>
       </CopyToClipboard>
     </h1>
 

--- a/src/components/Palette/Palette.js
+++ b/src/components/Palette/Palette.js
@@ -32,14 +32,14 @@ const propTypes = {
   ).isRequired,
   onClickPaletteButton: PropTypes.func.isRequired,
   onClickCopyPaletteButton: PropTypes.func.isRequired,
-  paletteGenneratingUrl: PropTypes.string.isRequired,
+  activePageURL: PropTypes.string.isRequired,
 };
 
-const Palette = ({ palette, onClickPaletteButton, onClickCopyPaletteButton, paletteGenneratingUrl }) => (
+const Palette = ({ palette, onClickPaletteButton, onClickCopyPaletteButton, activePageURL }) => (
   <div className="palette">
     <h1 className="title palette__title">
       <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Palette</span>
-      <CopyToClipboard onCopy={(onClickCopyPaletteButton)} text={paletteGenneratingUrl}>
+      <CopyToClipboard onCopy={(onClickCopyPaletteButton)} text={activePageURL}>
         <i
           role="button"
           tabIndex={0}

--- a/src/components/Palette/Palette.js
+++ b/src/components/Palette/Palette.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 import PaletteTile from '../../containers/PaletteTile';
 import './Palette.css';
@@ -30,19 +31,30 @@ const propTypes = {
     })
   ).isRequired,
   onClickPaletteButton: PropTypes.func.isRequired,
+  onClickCopyPaletteButton: PropTypes.func.isRequired,
+  paletteGenneratingUrl: PropTypes.string.isRequired,
 };
 
-
-const Palette = ({ palette, onClickPaletteButton }) => (
+const Palette = ({ palette, onClickPaletteButton, onClickCopyPaletteButton, paletteGenneratingUrl }) => (
   <div className="palette">
     <h1 className="title palette__title">
       <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Palette</span>
-      <i
-        className="material-icons"
-        style={{ display: 'inline-block', verticalAlign: 'middle', marginLeft: '5px', color: 'slategray' }}
-      >
-        insert_link
-      </i>
+      <CopyToClipboard onCopy={(onClickCopyPaletteButton)} text={paletteGenneratingUrl}>
+        <i
+          role="button"
+          tabIndex={0}
+          className="material-icons"
+          style={{
+            display: 'inline-block',
+            verticalAlign: 'middle',
+            marginLeft: '5px',
+            color: 'slategray',
+            cursor: 'pointer',
+          }}
+        >
+          insert_link
+        </i>
+      </CopyToClipboard>
     </h1>
 
     <table className="table palette__table palette__table_with-head" style={{ margin: '0 0 25px 0' }}>

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,7 +1,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { showPaletteCodeModal } from '../actions/modal';
-import { closeSnackBar } from '../actions/snackBar';
+import { closeSnackBar, showSnackBarWithText } from '../actions/snackBar';
 import { setInitialPaletteColors, changePaletteColor } from '../actions/palette';
 
 import App from '../components/App/App';
@@ -13,6 +13,7 @@ function mapStateToProps(state) {
     palette,
     isVisibleSnackBar: snackBar.isVisible,
     snackBarText: snackBar.text,
+    paletteGenneratingUrl: window.location.href,
   };
 }
 
@@ -23,6 +24,7 @@ function mapDispatchToProps(dispatch) {
     closeSnackBar,
     setInitialPaletteColors,
     changePaletteColor,
+    showSnackBarWithText,
   }, dispatch);
 }
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -13,7 +13,7 @@ function mapStateToProps(state) {
     palette,
     isVisibleSnackBar: snackBar.isVisible,
     snackBarText: snackBar.text,
-    paletteGenneratingUrl: window.location.href,
+    activePageURL: window.location.href,
   };
 }
 


### PR DESCRIPTION
@hazolsky I m not sure about this [line](https://github.com/LiveTyping/android-colors/compare/feature/copy-link-to-palette-by-clicking-on-link?expand=1#diff-729498c5aa552df999cc9e99e87f961cR41)
. I have to save the url in the store and getting this in middleware or getting this url by `window.location.href` in component is ok?